### PR TITLE
Updated endpoints.

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -4,7 +4,7 @@ cromiam {
 
   http {
     interface = "0.0.0.0"
-    port = 8000
+    port = 8001
   }
 }
 
@@ -15,5 +15,9 @@ sam {
 
 cromwell {
   interface = "0.0.0.0"
-  port = 8001
+  port = 8000
+}
+
+google {
+  client_id = "google_client_id"
 }

--- a/src/main/resources/swagger/cromiam.yaml
+++ b/src/main/resources/swagger/cromiam.yaml
@@ -11,9 +11,8 @@ info:
   version: ''
 produces:
   - application/json
-basePath: /api
 paths:
-  '/workflows/{version}/{id}/abort':
+  '/api/workflows/{version}/{id}/abort':
     post:
       summary: Abort a workflow based on workflow id
       parameters:
@@ -46,7 +45,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}':
+  '/api/workflows/{version}':
     post:
       summary: Submit a new workflow for execution
       consumes:
@@ -117,7 +116,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}/batch':
+  '/api/workflows/{version}/batch':
     post:
       summary: Submit a batch of new workflows for execution
       consumes:
@@ -170,7 +169,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}/{id}/outputs':
+  '/api/workflows/{version}/{id}/outputs':
     get:
       summary: Query for workflow outputs based on workflow id
       parameters:
@@ -199,7 +198,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}/{id}/labels':
+  '/api/workflows/{version}/{id}/labels':
     patch:
       summary: Add new labels or update values for existing label keys by workflow id.
       parameters:
@@ -238,7 +237,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}/query':
+  '/api/workflows/{version}/query':
     get:
       summary: Query workflows by start dates, end dates, names, ids, or statuses.
       parameters:
@@ -350,7 +349,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}/{id}/status':
+  '/api/workflows/{version}/{id}/status':
     get:
       summary: Query for workflow status based on workflow id
       parameters:
@@ -381,7 +380,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}/{id}/logs':
+  '/api/workflows/{version}/{id}/logs':
     get:
       summary: Query for the standard output and error of all calls in a workflow
       parameters:
@@ -410,7 +409,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}/{id}/metadata':
+  '/api/workflows/{version}/{id}/metadata':
     get:
       summary: Query for workflow and call-level metadata for a specified workflow
       parameters:
@@ -595,7 +594,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}/callcaching/diff':
+  '/api/workflows/{version}/callcaching/diff':
     get:
       summary: Return the hash differential between two calls
       parameters:
@@ -649,7 +648,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}/backends':
+  '/api/workflows/{version}/backends':
     get:
       summary: Returns the backends supported by this Cromwell.
       parameters:

--- a/src/main/scala/cromiam/server/CromIamServer.scala
+++ b/src/main/scala/cromiam/server/CromIamServer.scala
@@ -20,6 +20,8 @@ object CromIamServer extends HttpApp with CromIamApiService with SwaggerService 
     case Invalid(errors) => throw new Exception("Bad CromIAM configuration:" + errors.toList.mkString("\n", "\n", "\n"))
   }
 
+  override lazy val oauthClientId: String = configuration.googleConfig.clientId
+
   def run(): Unit = {
     CromIamServer.startServer(configuration.cromIamConfig.http.interface, configuration.cromIamConfig.http.port, configuration.cromIamConfig.serverSettings)
   }

--- a/src/main/scala/cromiam/server/config/CromIamServerConfig.scala
+++ b/src/main/scala/cromiam/server/config/CromIamServerConfig.scala
@@ -10,15 +10,19 @@ import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 import cromiam.server.config.CromIamServerConfig._
 
-final case class CromIamServerConfig(cromIamConfig: CromIamConfig, cromwellConfig: ServiceConfig, samConfig: ServiceConfig)
+final case class CromIamServerConfig(cromIamConfig: CromIamConfig,
+                                     cromwellConfig: ServiceConfig,
+                                     samConfig: ServiceConfig,
+                                     googleConfig: GoogleConfig)
 
 object CromIamServerConfig {
   def getFromConfig(conf: Config): ErrorOr[CromIamServerConfig] = {
     val cromIamConfig = CromIamConfig.getFromConfig(conf, "cromiam")
     val cromwellConfig = ServiceConfig.getFromConfig(conf, "cromwell")
     val samConfig = ServiceConfig.getFromConfig(conf, "sam")
+    val googleConfig = GoogleConfig.getFromConfig(conf, "google")
 
-    (cromIamConfig |@| cromwellConfig |@| samConfig) map CromIamServerConfig.apply
+    (cromIamConfig |@| cromwellConfig |@| samConfig |@| googleConfig) map CromIamServerConfig.apply
   }
 
   private[config] def getValidatedConfigPath[A](typename: String, conf: Config, path: String, getter: (Config, String) => A): ErrorOr[A] = {
@@ -65,5 +69,14 @@ object ServiceConfig {
     val server = conf.getValidatedString(s"$basePath.interface")
     val port = conf.getValidatedInt(s"$basePath.port")
     (server |@| port) map ServiceConfig.apply
+  }
+}
+
+final case class GoogleConfig(clientId: String)
+
+object GoogleConfig {
+  private[config] def getFromConfig(conf: Config, basePath: String): ErrorOr[GoogleConfig] = {
+    val clientId = conf.getValidatedString(s"$basePath.client_id")
+    clientId map GoogleConfig.apply
   }
 }

--- a/src/test/scala/cromiam/webservice/CromIamApiServiceSpec.scala
+++ b/src/test/scala/cromiam/webservice/CromIamApiServiceSpec.scala
@@ -20,7 +20,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
   }
 
   "Stats endpoint" should "be forbidden" in {
-    Get("/api/engine/v1/stats") ~> allRoutes ~> check {
+    Get("/engine/v1/stats") ~> allRoutes ~> check {
       status shouldBe Forbidden
       response.entity shouldBe CromIamApiService.CromIamStatsForbidden.entity
     }

--- a/src/test/scala/cromiam/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/src/test/scala/cromiam/webservice/SwaggerUiHttpServiceSpec.scala
@@ -39,6 +39,9 @@ object SwaggerUiHttpServiceSpec {
 class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
   behavior of "SwaggerUiHttpService"
 
+  override protected def rewriteSwaggerIndex(data: String): String =
+    data.replace("your-client-id", "replaced-client-id")
+
   it should "redirect / to /swagger" in {
     Get() ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.TemporaryRedirect)
@@ -62,6 +65,7 @@ class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
   it should "return index.html from the swagger-ui jar" in {
     Get("/swagger/index.html") ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.OK)
+      responseAs[String] should include("replaced-client-id")
     }
   }
 }


### PR DESCRIPTION
Swagger index.html now re-written (copied/modified from rawls):
- Replaces your-client-id the config google.client_id.
- Scope separator changed from a comma to a space.
- Default yaml changed to cromiam.yaml.
Version and status routes now served without protected /api prefix.
Switched default port for CromIAM to 8001, and the configuration for cromwell back to its default 8000.